### PR TITLE
Add issue_label_bot config

### DIFF
--- a/.github/issue_label_bot.yml
+++ b/.github/issue_label_bot.yml
@@ -1,0 +1,2 @@
+label-alias:
+  feature_request: 'enhancement'


### PR DESCRIPTION
This PR configures **issue_label_bot** to use the `enhancement` label instead of a custom `feature-request` one.