### PR TITLE
Remove github secret Codecov token

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -70,6 +70,4 @@ jobs:
         name: 'Upload coverage to Codacy'
       - uses: codecov/codecov-action@v1
         if: success()
-        with:
-          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         name: 'Upload coverage to CodeCov'


### PR DESCRIPTION
This token is no longer necessary since the project has been made public.